### PR TITLE
Create Want model and associate with User

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :wants, dependent: :destroy
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 

--- a/app/models/want.rb
+++ b/app/models/want.rb
@@ -1,0 +1,3 @@
+class Want < ApplicationRecord
+  belongs_to :user
+end

--- a/db/migrate/20260128071921_create_wants.rb
+++ b/db/migrate/20260128071921_create_wants.rb
@@ -1,0 +1,12 @@
+class CreateWants < ActiveRecord::Migration[7.2]
+  def change
+    create_table :wants do |t|
+      t.string :title
+      t.text :memo
+      t.date :deadline
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_25_014936) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_28_071921) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,4 +27,16 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_25_014936) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  create_table "wants", force: :cascade do |t|
+    t.string "title"
+    t.text "memo"
+    t.date "deadline"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_wants_on_user_id"
+  end
+
+  add_foreign_key "wants", "users"
 end

--- a/test/fixtures/wants.yml
+++ b/test/fixtures/wants.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  memo: MyText
+  deadline: 2026-01-28
+  user: one
+
+two:
+  title: MyString
+  memo: MyText
+  deadline: 2026-01-28
+  user: two

--- a/test/models/want_test.rb
+++ b/test/models/want_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class WantTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
やりたいことリスト（ Want モデル）を作成し、User と関連付けました。

## 対応内容
- Wantモデルの作成
- wantsテーブルの作成
- User / Want の関連付け追加
  - User has_many :wants
  - Want belongs_to :user

## 動作確認
- Rails console にて、User に紐づいた Want が作成できることを確認しました。

## 関連issue
issue 10