### PR TITLE
編集機能の追加

### DIFF
--- a/app/controllers/wants_controller.rb
+++ b/app/controllers/wants_controller.rb
@@ -1,5 +1,6 @@
 class WantsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_want, only: [ :edit, :update ]
 
   def index
     @wants = current_user.wants.order(created_at: :desc)
@@ -19,7 +20,23 @@ class WantsController < ApplicationController
     end
   end
 
+  def edit
+  end
+
+  def update
+    if @want.update(want_params)
+      redirect_to wants_path, notice: "更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
+
+  # 本人のWantしか取得できない（＝本人のみ操作可能）
+  def set_want
+    @want = current_user.wants.find(params[:id])
+  end
 
   def want_params
     params.require(:want).permit(:title, :memo, :deadline)

--- a/app/views/wants/edit.html.erb
+++ b/app/views/wants/edit.html.erb
@@ -1,0 +1,22 @@
+<h1>やりたいこと編集</h1>
+
+<%= form_with model: @want, local: true do |f| %>
+  <div>
+    <%= f.label :title, "やりたいこと" %><br>
+    <%= f.text_field :title %>
+  </div>
+
+  <div>
+    <%= f.label :memo, "メモ" %><br>
+    <%= f.text_area :memo %>
+  </div>
+
+  <div>
+    <%= f.label :deadline, "期限" %><br>
+    <%= f.date_field :deadline %>
+  </div>
+
+  <div>
+    <%= f.submit "更新" %>
+  </div>
+<% end %>

--- a/app/views/wants/index.html.erb
+++ b/app/views/wants/index.html.erb
@@ -3,7 +3,9 @@
 <% if @wants.any? %>
   <ul>
     <% @wants.each do |want| %>
-      <li><%= want.title %></li>
+      <li>
+        <%= want.title %>
+        <%= link_to "編集", edit_want_path(want) %></li>
     <% end %>
   </ul>
 <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root "pages#top"
   get "pages/top"
 
-  resources :wants, only: [ :index, :new, :create ]
+  resources :wants, only: [ :index, :new, :create, :edit, :update ]
 
   # health check
   get "up" => "rails/health#show", as: :rails_health_check


### PR DESCRIPTION
## 概要
やりたいこと（Want）の編集機能（edit / update）を実装しました。

## 実装内容
- Want の編集画面（edit）の追加
- Want の更新処理（update）の実装
- 一覧画面に編集リンクを追加
- current_user に紐づく Want のみ編集できるよう制限

## 動作確認
- 一覧から編集画面へ遷移できること
- 内容を更新後、一覧に反映されること
- 他ユーザーの Want は編集できないこと

## 関連issue
issue 13 やりたいこと編集(edit)
