### PR TITLE
削除機能追加

### DIFF
--- a/app/controllers/wants_controller.rb
+++ b/app/controllers/wants_controller.rb
@@ -1,6 +1,6 @@
 class WantsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_want, only: [ :edit, :update ]
+  before_action :set_want, only: [ :edit, :update, :destroy ]
 
   def index
     @wants = current_user.wants.order(created_at: :desc)
@@ -29,6 +29,11 @@ class WantsController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @want.destroy
+    redirect_to wants_path, notice: "削除しました"
   end
 
   private

--- a/app/views/wants/index.html.erb
+++ b/app/views/wants/index.html.erb
@@ -5,7 +5,10 @@
     <% @wants.each do |want| %>
       <li>
         <%= want.title %>
-        <%= link_to "編集", edit_want_path(want) %></li>
+        <%= link_to "編集", edit_want_path(want) %>
+        <%= link_to "削除", want_path(want),
+              data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" } %>
+      </li>
     <% end %>
   </ul>
 <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root "pages#top"
   get "pages/top"
 
-  resources :wants, only: [ :index, :new, :create, :edit, :update ]
+  resources :wants, only: [ :index, :new, :create, :edit, :update, :destroy ]
 
   # health check
   get "up" => "rails/health#show", as: :rails_health_check


### PR DESCRIPTION
## 概要
やりたいこと（Want）の削除機能を実装しました。

## 実装内容
- Want の削除処理（destroy）を追加
- 一覧画面に削除リンクを追加（確認ダイアログ付き）
- current_user に紐づく Want のみ削除可能に制限

## 動作確認
- 一覧画面から削除できること
- 確認ダイアログが表示されること
- 削除後、一覧から該当データが消えること
- 他ユーザーの Want は削除できないこと

## 関連issue
issue 14 : やりたいこと削除
