### PR TITLE
やりたいことゼロの時の表示を作成

### DIFF
--- a/app/views/wants/index.html.erb
+++ b/app/views/wants/index.html.erb
@@ -11,6 +11,16 @@
       </li>
     <% end %>
   </ul>
+
 <% else %>
-  <p>まだ登録がありません。</p>
+  <div style="text-align:center; margin-top:30px; padding:30px; background-color:#f3f4f6; border-radius:8px;">
+    <p style="font-size:18px; margin-bottom:8px;">まだ登録がありません。</p>
+    <p style="color:#6b7280; margin-bottom:16px;">今思い浮かぶ小さなことから書いてみましょう。</p>
+    <p style="color:#6b7280; font-size:14px; margin-bottom:20px;">例：温泉旅行に行く / 映画を10本見る</p>
+
+    <%= link_to "＋ やりたいことを追加する",
+          new_want_path,
+          style: "padding:12px 24px; background-color:#3b82f6; color:white;
+                  border-radius:4px; text-decoration:none; display:inline-block;" %>
+  </div>
 <% end %>


### PR DESCRIPTION
なぜ必要か
やりたいこと一覧（index）で、データが0件の場合の表示が必要
初回ユーザーが次に何をすればよいか分かるようにしたい

必要なこと
初回利用時にやりたいことが未登録の場合でも、ユーザーが迷わず次の行動（登録）に進めるようにする

やること
やりたいことが0件の状態で一覧ページにアクセスすると、案内文と新規作成ボタンが表示されること
新規作成ボタンからやりたいこと新規作成画面に遷移できること
1件以上登録されている場合は、通常の一覧表示になること

関連issue
issue やりたいこと一覧（index）で、データが0件の場合の画面作成
