### PR TITLE
生年月日登録ページ作成

### DIFF
--- a/app/controllers/birthdays_controller.rb
+++ b/app/controllers/birthdays_controller.rb
@@ -1,0 +1,28 @@
+class BirthdaysController < ApplicationController
+  before_action :authenticate_user!
+  before_action :redirect_if_birthday_present, only: %i[edit update]
+
+  def edit
+  end
+
+  def update
+    if current_user.update(birthday_params)
+      redirect_to wants_path, notice: "生年月日を登録しました！"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def birthday_params
+    b = params.require(:user).permit(:birthday)
+    normalized = b[:birthday].to_s.gsub(/[^\d]/, "") # 数字以外全部除去
+    b[:birthday] = normalized
+    b
+  end
+
+  def redirect_if_birthday_present
+    redirect_to wants_path if current_user.birthday.present?
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,11 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  protected
+
+  def after_sign_up_path_for(_resource)
+    edit_birthday_path
+  end
+
+  def after_inactive_sign_up_path_for(_resource)
+    edit_birthday_path
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,12 +5,13 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   validates :name, presence: true
-  validates :birthday, presence: true
-  validate :birthday_must_be_yyyymmdd
+
+  # 誕生日は「後で入力」なので update のときだけ必須にする
+  validates :birthday, presence: true, on: :update
+  validate :birthday_must_be_yyyymmdd, if: -> { birthday.present? }
 
   AVERAGE_LIFE_SPAN = 84.0
 
-  # 年齢を計算
   def age
     return nil if birthday.nil?
 
@@ -20,7 +21,6 @@ class User < ApplicationRecord
     age
   end
 
-  # 人生進捗率（%）
   def life_progress_rate
     return nil if age.nil?
 

--- a/app/views/birthdays/edit.html.erb
+++ b/app/views/birthdays/edit.html.erb
@@ -1,0 +1,75 @@
+<div class="min-h-screen bg-[#FBF6E9]">
+  <div class="mx-auto max-w-[420px] px-4 py-10">
+
+    <div class="text-center">
+      <h1 class="text-3xl font-extrabold text-[#111827] leading-tight">
+        あなたの誕生日を教えて
+      </h1>
+
+      <div class="mx-auto mt-5 w-fit rounded-2xl border-2 border-[#111827] bg-white px-5 py-3 shadow-[6px_6px_0_#111827]">
+        <p class="text-sm font-extrabold text-[#FF6B6B] leading-6">
+          生年月日を入力すると、<br>
+          あなたの人生の残り日数がわかるよ！
+        </p>
+      </div>
+    </div>
+
+    <% if current_user.errors.any? %>
+      <div class="mt-6 rounded-2xl border-2 border-[#111827] bg-[#FFE1E1] px-5 py-4 shadow-[6px_6px_0_#111827]">
+        <p class="text-sm font-extrabold text-[#111827]">入力内容を確認してね 👀</p>
+        <ul class="mt-3 list-disc pl-5 text-sm font-semibold text-[#111827]">
+          <% current_user.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <!-- 入力カード -->
+    <div class="mt-10 rounded-2xl border-2 border-[#111827] bg-white/70 px-5 py-6 shadow-[6px_6px_0_#111827]">
+      <p class="text-xs font-extrabold tracking-widest text-[#111827]">BIRTHDAY</p>
+
+      <%= form_with model: current_user, url: birthday_path, method: :patch, data: { turbo: false } do |f| %>
+        <label class="mt-3 block text-sm font-extrabold text-[#111827]">
+          生年月日（YYYY/MM/DD）
+        </label>
+
+        <div class="mt-2 rounded-2xl border-2 border-[#111827] bg-white px-4 py-3 shadow-[4px_4px_0_#111827]">
+          <%= f.text_field :birthday,
+                value: (current_user.birthday.present? ? current_user.birthday.strftime("%Y/%m/%d") : ""),
+                placeholder: "1995/01/01",
+                inputmode: "numeric",
+                maxlength: 10,
+                class: "w-full bg-transparent text-2xl font-extrabold tracking-tight text-[#111827] placeholder:text-[#9CA3AF] outline-none",
+                id: "birthday_text" %>
+        </div>
+
+        <div class="mt-8">
+          <%= f.submit "次へ進む",
+                class: "w-full rounded-[32px] border-2 border-[#111827] bg-[#74C69D] px-5 py-5 text-xl font-extrabold text-white
+                        shadow-[6px_6px_0_#111827] active:translate-x-[1px] active:translate-y-[1px]" %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="mt-10 text-center">
+      <%= link_to root_path, class: "inline-flex items-center gap-1 text-sm font-extrabold text-[#111827]" do %>
+        <span aria-hidden="true">‹</span> 戻る
+      <% end %>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  // 入力を「YYYY/MM/DD」に寄せる（数字だけ打っても整形）
+  const el = document.getElementById("birthday_text");
+  if (el) {
+    el.addEventListener("input", () => {
+      let v = el.value.replace(/[^\d]/g, "").slice(0, 8); // YYYYMMDD
+      if (v.length >= 5) v = v.slice(0,4) + "/" + v.slice(4);
+      if (v.length >= 8) v = v.slice(0,7) + "/" + v.slice(7);
+      el.value = v;
+    });
+  }
+</script>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -23,7 +23,7 @@
 
     <!-- フォーム -->
     <div class="mt-6 rounded-2xl border-2 border-[#111827] bg-white/70 px-5 py-6 text-left shadow-[6px_6px_0_#111827]">
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: false }) do |f| %>
 
         <!-- 名前 -->
         <div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <h2>ログイン</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+<%= form_for(resource, as: resource_name, url: session_path(resource_name), data: { turbo: false }) do |f| %>
   <div class="field">
     <p><%= f.label :email, "メールアドレス" %></p>
     <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { registrations: "users/registrations" }
 
   root "pages#top"
   get "pages/top"
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
       patch :achieve
     end
   end
+
+  # 生年月日登録（オンボーディング）
+  resource :birthday, only: [ :edit, :update ]
 
   # health check
   get "up" => "rails/health#show", as: :rails_health_check


### PR DESCRIPTION
#なぜ必要か
・生年月日のみの入力ページにすることで、「進捗率・残り日数を表示するために必要な入力」であることを強調するため
・人生進捗率（ライフゲージ）などの計算に生年月日が必須なため

#必要なこと
・新規登録後に生年月日入力画面へ遷移する
・YYYYMMDD形式で生年月日を入力・保存できる
・入力エラー時に分かりやすいメッセージを表示する
・登録完了後はやりたいことリスト画面へ遷移する
・生年月日を元に進捗率・残り日数を表示すると明示する

#やること
・BirthdaysController の edit / update を実装
・生年月日入力画面（birthdays/edit.html.erb）を作成
・Userモデルのバリデーションを登録フローに合わせて調整
・新規登録 → 生年月日入力 → wants一覧 の遷移を確認