### PR TITLE
達成写真

### DIFF
--- a/app/controllers/wants_controller.rb
+++ b/app/controllers/wants_controller.rb
@@ -82,9 +82,13 @@ class WantsController < ApplicationController
   def achieve
     already_achieved = @want.achieved?
 
+    if achieve_params[:achieved_image].present?
+      @want.achieved_image.attach(achieve_params[:achieved_image])
+    end
+
     if @want.achieve(
-      achievement_note: params.dig(:want, :achievement_note),
-      achieved_at_input: params.dig(:want, :achieved_at),
+      achievement_note: achieve_params[:achievement_note],
+      achieved_at_input: achieve_params[:achieved_at],
       now: Time.current
     )
       notice = already_achieved ? "思い出メモを更新しました！" : "達成を記録しました！"
@@ -102,6 +106,10 @@ class WantsController < ApplicationController
 
   def want_params
     params.require(:want).permit(:title, :memo, :target_date, :picture)
+  end
+
+  def achieve_params
+    params.require(:want).permit(:achievement_note, :achieved_at, :achieved_image)
   end
 
   # 年齢が入力されたときだけ target_date を計算してセットする

--- a/app/models/want.rb
+++ b/app/models/want.rb
@@ -1,6 +1,7 @@
 class Want < ApplicationRecord
   belongs_to :user
   has_one_attached :picture
+  has_one_attached :achieved_image
 
   validates :title, presence: true
 

--- a/app/views/wants/achieve_form.html.erb
+++ b/app/views/wants/achieve_form.html.erb
@@ -25,6 +25,32 @@
                 placeholder: "達成した理由、嬉しかったこと、学びなど" %>
         </div>
 
+        <!-- 達成写真 -->
+        <div class="mt-4">
+          <%= f.label :achieved_image, "達成の写真", class: "text-sm font-bold text-[#6B7280]" %>
+
+          <% if @want.achieved_image.attached? %>
+            <div class="mt-2">
+              <%= image_tag @want.achieved_image.variant(resize_to_limit: [400, 400]),
+                    alt: "達成写真",
+                    class: "max-h-48 w-full rounded-xl object-cover" %>
+            </div>
+          <% end %>
+
+          <div class="mt-2">
+            <%= f.file_field :achieved_image,
+                  accept: "image/*",
+                  class: "w-full text-sm text-[#6B7280] file:mr-3 file:rounded-full file:border-0 file:bg-[#1FA971] file:px-4 file:py-2 file:text-sm file:font-bold file:text-white hover:file:opacity-90",
+                  data: { controller: "preview", preview_target: "input", action: "change->preview#show" } %>
+          </div>
+
+          <div class="mt-3 hidden" data-preview-target="wrapper">
+            <img src="" alt="プレビュー" class="max-h-48 w-full rounded-xl object-cover" data-preview-target="image">
+          </div>
+
+          <p class="mt-1 text-xs font-bold text-[#9CA3AF]">未設定でもOK</p>
+        </div>
+
         <div class="mt-5 flex gap-3">
           <%= f.submit "達成を保存する",
                 data: { turbo_confirm: "達成として記録しますか？" },

--- a/app/views/wants/show.html.erb
+++ b/app/views/wants/show.html.erb
@@ -53,6 +53,17 @@
           </p>
         </div>
 
+        <% if @want.achieved_image.attached? %>
+          <div class="mt-4">
+            <p class="text-sm font-extrabold text-[#6B7280]">達成の写真</p>
+            <div class="mt-2">
+              <%= image_tag @want.achieved_image.variant(resize_to_limit: [520, 520]),
+                    alt: "達成写真",
+                    class: "w-full rounded-xl object-cover" %>
+            </div>
+          </div>
+        <% end %>
+
         <% if @want.achievement_note.present? %>
           <div class="mt-4">
             <p class="text-sm font-extrabold text-[#6B7280]">達成メモ</p>


### PR DESCRIPTION
#なぜ必要か
・達成体験を深く残すため
・記憶の配当（思い出の可視化）の実現のため

#必要なこと
・達成画像保存機能

#やること
・achieved_image添付設定
・達成フォーム修正
・表示画面更新