### PR TITLE
プライバシー、利用規約

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,4 +4,10 @@ class PagesController < ApplicationController
 
   def die_with_zero
   end
+
+  def terms
+  end
+
+  def privacy
+  end
 end

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,0 +1,89 @@
+<div class="min-h-screen bg-[#FBF6E9]">
+  <div class="mx-auto max-w-[680px] px-4 py-10">
+
+    <!-- ヘッダー -->
+    <div class="mb-8 flex items-center gap-3">
+      <%= link_to root_path, class: "text-[#6B7280] hover:text-[#111827] text-sm" do %>
+        ← トップへ
+      <% end %>
+    </div>
+
+    <h1 class="text-2xl font-extrabold text-[#111827] mb-2">プライバシーポリシー</h1>
+    <p class="text-sm text-[#6B7280] mb-8">最終更新日：2026年2月23日</p>
+
+    <div class="flex flex-col gap-6 text-sm leading-7 text-[#374151]">
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">1. 基本方針</h2>
+        <p>ライフゲージ（以下「本サービス」）は、ユーザーの個人情報の取扱いについて、以下のとおりプライバシーポリシーを定め、個人情報の保護に努めます。</p>
+      </section>
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">2. 取得する情報</h2>
+        <p>本サービスでは、以下の情報を取得します。</p>
+        <ul class="mt-3 list-disc pl-5 flex flex-col gap-1">
+          <li>メールアドレス（アカウント登録時）</li>
+          <li>ニックネーム（任意）</li>
+          <li>生年月日（ライフゲージ計算のため）</li>
+          <li>やりたいこと・達成記録（投稿内容）</li>
+          <li>投稿に添付した画像</li>
+          <li>アクセスログ（IPアドレス・ブラウザ情報等）</li>
+        </ul>
+      </section>
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">3. 情報の利用目的</h2>
+        <p>取得した情報は、以下の目的のために利用します。</p>
+        <ul class="mt-3 list-disc pl-5 flex flex-col gap-1">
+          <li>本サービスの提供・運営のため</li>
+          <li>ユーザーの本人確認・認証のため</li>
+          <li>人生進捗率の計算・表示のため</li>
+          <li>サービスの改善・新機能の開発のため</li>
+          <li>利用規約違反への対応のため</li>
+        </ul>
+      </section>
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">4. 第三者への提供</h2>
+        <p>以下の場合を除き、取得した個人情報を第三者に提供することはありません。</p>
+        <ul class="mt-3 list-disc pl-5 flex flex-col gap-1">
+          <li>ユーザーの同意がある場合</li>
+          <li>法令に基づく場合</li>
+          <li>人の生命・身体・財産の保護のため必要であり、ユーザーの同意を得ることが困難な場合</li>
+        </ul>
+      </section>
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">5. 公開情報について</h2>
+        <p>本サービスでは、ユーザーが「公開」に設定したやりたいこと・達成記録は、他のユーザーや非ログインユーザーが閲覧できます。公開設定にする際はご注意ください。非公開のままにすることで、自分だけが閲覧できます。</p>
+      </section>
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">6. 情報の管理</h2>
+        <p>個人情報の漏えい・紛失・改ざんを防ぐため、適切なセキュリティ対策を講じます。ただし、インターネットを通じた情報の完全な安全性を保証するものではありません。</p>
+      </section>
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">7. 開示・訂正・削除</h2>
+        <p>ユーザーは、自身の個人情報の開示・訂正・削除を求めることができます。アカウントの削除により、登録情報は削除されます。</p>
+      </section>
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">8. Cookie の使用</h2>
+        <p>本サービスでは、ログイン状態の維持・セッション管理のために Cookie を使用します。ブラウザの設定により Cookie を無効にすることも可能ですが、一部機能が利用できなくなる場合があります。</p>
+      </section>
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">9. プライバシーポリシーの変更</h2>
+        <p>本ポリシーの内容は、法令変更やサービス変更に伴い、予告なく変更することがあります。変更後のポリシーは、本ページに掲載された時点から効力を生じます。</p>
+      </section>
+
+    </div>
+
+    <p class="mt-10 text-center text-xs text-[#6B7280]">
+      © Life Gauge
+      <%= link_to "利用規約", terms_path, class: "underline hover:text-[#111827]" %>
+    </p>
+
+  </div>
+</div>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,0 +1,93 @@
+<div class="min-h-screen bg-[#FBF6E9]">
+  <div class="mx-auto max-w-[680px] px-4 py-10">
+
+    <!-- ヘッダー -->
+    <div class="mb-8 flex items-center gap-3">
+      <%= link_to root_path, class: "text-[#6B7280] hover:text-[#111827] text-sm" do %>
+        ← トップへ
+      <% end %>
+    </div>
+
+    <h1 class="text-2xl font-extrabold text-[#111827] mb-2">利用規約</h1>
+    <p class="text-sm text-[#6B7280] mb-8">最終更新日：2026年2月23日</p>
+
+    <div class="flex flex-col gap-6 text-sm leading-7 text-[#374151]">
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">第1条（適用）</h2>
+        <p>本利用規約（以下「本規約」）は、ライフゲージ（以下「本サービス」）の利用条件を定めるものです。登録ユーザーの皆さまには、本規約に従って本サービスをご利用いただきます。</p>
+      </section>
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">第2条（利用登録）</h2>
+        <p>本サービスへの登録を希望する方は、本規約に同意のうえ、所定の方法により利用登録を申請してください。登録申請者が以下に該当すると判断した場合、利用登録を承認しないことがあります。</p>
+        <ul class="mt-3 list-disc pl-5 flex flex-col gap-1">
+          <li>虚偽の情報を届け出た場合</li>
+          <li>過去に本規約違反等により利用停止となったことがある場合</li>
+          <li>その他、利用登録が適当でないと判断した場合</li>
+        </ul>
+      </section>
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">第3条（ユーザーIDおよびパスワードの管理）</h2>
+        <p>ユーザーは、自己の責任においてメールアドレスおよびパスワードを適切に管理するものとします。ユーザーは、いかなる場合にも、メールアドレスおよびパスワードを第三者に譲渡または貸与することはできません。</p>
+      </section>
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">第4条（禁止事項）</h2>
+        <p>ユーザーは、本サービスの利用にあたり、以下の行為をしてはなりません。</p>
+        <ul class="mt-3 list-disc pl-5 flex flex-col gap-1">
+          <li>法令または公序良俗に違反する行為</li>
+          <li>犯罪行為に関連する行為</li>
+          <li>他のユーザーに対する嫌がらせや誹謗中傷</li>
+          <li>本サービスのサーバーやネットワークへの不正アクセス</li>
+          <li>本サービスの運営を妨害するおそれのある行為</li>
+          <li>他のユーザーの個人情報を収集・蓄積する行為</li>
+          <li>その他、不適切と判断する行為</li>
+        </ul>
+      </section>
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">第5条（投稿コンテンツ）</h2>
+        <p>ユーザーが本サービスに投稿したコンテンツ（テキスト・画像等）について、投稿者自身が一切の責任を負うものとします。公開設定にした投稿は、他のユーザーが閲覧できる状態になります。他者の権利を侵害するコンテンツの投稿は禁止します。</p>
+      </section>
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">第6条（サービスの停止等）</h2>
+        <p>以下のいずれかに該当する場合、事前の通知なく本サービスの全部または一部の提供を停止または中断することがあります。</p>
+        <ul class="mt-3 list-disc pl-5 flex flex-col gap-1">
+          <li>サーバー等のシステムの保守点検を行う場合</li>
+          <li>地震・火災・停電などの不可抗力により、サービス提供が困難な場合</li>
+          <li>その他、サービス提供が困難と判断した場合</li>
+        </ul>
+      </section>
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">第7条（免責事項）</h2>
+        <p>本サービスに関して生じた損害について、一切の責任を負いません。本サービスは現状のまま提供されており、特定の目的への適合性・正確性・完全性等について保証しません。</p>
+      </section>
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">第8条（サービス内容の変更・終了）</h2>
+        <p>ユーザーへの事前の通知なく、本サービスの内容を変更・停止・終了することができるものとします。これによってユーザーに生じた損害について一切の責任を負いません。</p>
+      </section>
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">第9条（利用規約の変更）</h2>
+        <p>本規約は、必要に応じて変更することがあります。変更後の規約は、本サービス上に掲示された時点より効力を生じるものとします。</p>
+      </section>
+
+      <section class="rounded-2xl border-2 border-[#111827] bg-white px-6 py-5 shadow-[4px_4px_0_#111827]">
+        <h2 class="text-base font-extrabold text-[#111827] mb-3">第10条（準拠法・裁判管轄）</h2>
+        <p>本規約の解釈にあたっては、日本法を準拠法とします。本サービスに関する紛争については、日本の裁判所を専属的合意管轄とします。</p>
+      </section>
+
+    </div>
+
+    <p class="mt-10 text-center text-xs text-[#6B7280]">
+      © Life Gauge
+      <%= link_to "プライバシーポリシー", privacy_path, class: "underline hover:text-[#111827]" %>
+    </p>
+
+  </div>
+</div>

--- a/app/views/pages/top.html.erb
+++ b/app/views/pages/top.html.erb
@@ -120,9 +120,14 @@
       </div>
     </div>
 
-    <p class="mt-10 text-xs text-[#6B7280]">
-      © Life Gauge
-    </p>
+    <div class="mt-10 flex flex-col items-center gap-2">
+      <div class="flex gap-4 text-xs text-[#6B7280]">
+        <%= link_to "利用規約", terms_path, class: "underline hover:text-[#111827]" %>
+        <span>|</span>
+        <%= link_to "プライバシーポリシー", privacy_path, class: "underline hover:text-[#111827]" %>
+      </div>
+      <p class="text-xs text-[#6B7280]">© Life Gauge</p>
+    </div>
 
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,4 +40,8 @@ Rails.application.routes.draw do
 
   # Die With Zero紹介ページ
   get "die_with_zero", to: "pages#die_with_zero", as: :die_with_zero
+
+  # 利用規約・プライバシーポリシー
+  get "terms",   to: "pages#terms",   as: :terms
+  get "privacy", to: "pages#privacy", as: :privacy
 end


### PR DESCRIPTION
#なぜ必要か
・個人情報（メールアドレス・投稿データ）を扱うため
・本番運用を想定したプロダクト設計であることを示すため
・信頼性の担保

#必要なこと
・利用規約・プライバシーポリシーページ作成
・トップページの下部へのリンク設置

#やること
・利用規約・プライバシーポリシーページ作成
・トップページの下部にリンク追加

